### PR TITLE
fix: check if process.send exists

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -180,7 +180,7 @@ app
         console.log("Server started at ", `http://localhost:${port}`);
         console.log("Queue UI at ", `http://localhost:${port}/queue/ui`);
         // For PM2 to know that our server is up
-        process.send("ready");
+        if (process.send) process.send("ready");
       } catch (err) {
         console.error("server threw error on startup: ", err);
         fastify.log.error(err);


### PR DESCRIPTION
Running without this check gives me a `process.send` is undefined error, because the server wasn't "spawned from IPC channel".

> If Node.js was not spawned with an IPC channel, process.send will be undefined.

Ref: https://nodejs.org/api/process.html#processsendmessage-sendhandle-options-callback