### PR TITLE
Fixed centered tagline on small devices

### DIFF
--- a/app/home/home.module.scss
+++ b/app/home/home.module.scss
@@ -18,7 +18,8 @@
 .tagline {
   margin-bottom: 2rem;
   color: var(--font-color-subtext);
-
+  text-align: center;
+  
   @media (max-width: 480px) {
     margin-bottom: 1.5rem;
   }


### PR DESCRIPTION
The tagline was not centered in devices with small width size.

![image](https://github.com/pastelsky/tsdocs/assets/87870889/d47edcd9-9d26-47aa-9898-fa2eb55dbdb9)
![image](https://github.com/pastelsky/tsdocs/assets/87870889/1c7fdebb-c3b4-4aa8-8e48-6d87e540e61d)
