### PR TITLE
feat: make Home/End keys usable in the search box

### DIFF
--- a/client/components/SearchBox/SearchBox.tsx
+++ b/client/components/SearchBox/SearchBox.tsx
@@ -56,7 +56,7 @@ export default function SearchBox({
       getPackageSuggestion(inputValue, styles.searchHighlight).then(
         (suggestions) => {
           setSuggestions(suggestions);
-        }
+        },
       );
     },
     items: suggestions,
@@ -75,7 +75,15 @@ export default function SearchBox({
             placeholder="Search npm packages"
             className={styles.searchInput}
             spellCheck={false}
-            {...getInputProps()}
+            {...getInputProps({
+              onKeyDown: (event) => {
+                // usable Home/End buttons
+                // https://github.com/pastelsky/tsdocs/issues/3
+                // reference: https://github.com/downshift-js/downshift#customizing-handlers
+                if (event.key == "Home" || event.key == "End")
+                  event.nativeEvent["preventDownshiftDefault"] = true;
+              },
+            })}
             // prevent key hijack by typedoc search
             // https://github.com/pastelsky/tsdocs/issues/2
             onKeyDown={(...args) => {

--- a/client/components/SearchBox/SearchBox.tsx
+++ b/client/components/SearchBox/SearchBox.tsx
@@ -77,6 +77,10 @@ export default function SearchBox({
             spellCheck={false}
             {...getInputProps({
               onKeyDown: (event) => {
+                // prevent key hijack by typedoc search
+                // https://github.com/pastelsky/tsdocs/issues/2
+                event.stopPropagation();
+
                 // usable Home/End buttons
                 // https://github.com/pastelsky/tsdocs/issues/3
                 // reference: https://github.com/downshift-js/downshift#customizing-handlers
@@ -84,12 +88,6 @@ export default function SearchBox({
                   event.nativeEvent["preventDownshiftDefault"] = true;
               },
             })}
-            // prevent key hijack by typedoc search
-            // https://github.com/pastelsky/tsdocs/issues/2
-            onKeyDown={(...args) => {
-              args[0].stopPropagation();
-              return getInputProps().onKeyDown(...args);
-            }}
             autoFocus={autoFocus}
           />
           {showVersionDropdown && initialVersion && (


### PR DESCRIPTION
Closing #3.

Also, I think that input's `onKeyDown` can be moved to Downshift's `onKeyDown` inside `getInputProps`, according to the [docs](https://github.com/downshift-js/downshift#customizing-handlers).

```tsx
{...getInputProps({
  onKeyDown: (event) => {
    // prevent key hijack by typedoc search
    // https://github.com/pastelsky/tsdocs/issues/2
    event.stopPropagation();
    ...
  }
})}
```

Didn't test it however