### PR TITLE
Removed unnecessary state from Index component

### DIFF
--- a/app/home/home.tsx
+++ b/app/home/home.tsx
@@ -10,8 +10,6 @@ import Footer from "../../client/components/Footer";
 import { useRouter } from "next/navigation";
 
 export default function Index() {
-  const [pkg, setPkg] = useState<string | null>(null);
-
   const router = useRouter();
 
   const handleSearchSubmit = async (pkg: string) => {
@@ -26,7 +24,7 @@ export default function Index() {
     <div className={styles.homePageContainer}>
       <Header
         minimal={true}
-        initialSearchValue={pkg}
+        initialSearchValue={null}
         onSearchSubmit={handleSearchSubmit}
       />
       <div className={styles.homePageContent}>


### PR DESCRIPTION
It seems unnecessary to manage the `initialSearchValue` property passed to the `<Header>` component within the `<Index>` component using state. 

Furthermore, since the state setter function is not being called and it's clear that only `null` is being passed to `initialSearchValue`, I believe the `pkg` state variable should be removed and `null` should be explicitly passed to `initialSearchValue`. 

If there's a need to manage it using state, you can always switch back to managing it with state when necessary, which I think is not the case currently.